### PR TITLE
Fix logging crash.

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -89,7 +89,11 @@ defmodule Stripe do
     {:error, error_struct}
   end
 
-  defp handle_response({:error, reason}) do
+  defp handle_response({:error, reason}) when is_binary(reason) do
     %APIConnectionError{message: "Network Error: #{reason}"}
+  end
+
+  defp handle_response({:error, reason}) do
+    %APIConnectionError{message: "Network Error: #{inspect(reason)}"}
   end
 end


### PR DESCRIPTION
When `Stripe.request/2` returns an error tuple containing a value which does not implement `String.Chars` we'd get an exception because we were trying to interpolate it straight into the log message.

According to dialyzer the error term is always a struct:

```elixir
  @spec do_call(:delete | :get | :post, any, any, keyword) ::
          {:error,
           %{
             :__exception__ => true,
             :__struct__ =>
               Stripe.APIError
               | Stripe.AuthenticationError
               | Stripe.CardError
               | Stripe.InvalidRequestError
               | Stripe.RateLimitError,
             :message => any,
             :type => <<_::64, _::_*8>>,
             optional(:code) => any,
             optional(:param) => any
           }}
          | {:ok, any}
          | Stripe.APIConnectionError.t()
```
I note that we also don't handle the `Stripe.APIConnectionError` type. Should I fix that too I wonder?
